### PR TITLE
Use System.arraycopy instead of Arrays.copyOf for compability

### DIFF
--- a/library/src/main/java/com/wuman/androidimageloader/util/concurrent/ArrayDeque.java
+++ b/library/src/main/java/com/wuman/androidimageloader/util/concurrent/ArrayDeque.java
@@ -799,7 +799,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
     public ArrayDeque<E> clone() {
         try {
             ArrayDeque<E> result = (ArrayDeque<E>) super.clone();
-            result.elements = Arrays.copyOf(elements, elements.length);
+            System.arraycopy(elements, 0, result.elements, 0, elements.length);
             return result;
 
         } catch (CloneNotSupportedException e) {


### PR DESCRIPTION
Arrays.copyOf needs api level 9
