### PR TITLE
Merge concurrent http request to same url into single req. Use native animation.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.wuman.androidimageloader"
+    android:versionCode="2110"
+    android:versionName="2.1.1" >
+
+    <uses-sdk android:minSdkVersion="4" />
+
+    <application />
+
+</manifest>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -18,10 +18,6 @@
             <artifactId>disklrucache</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.nineoldandroids</groupId>
-            <artifactId>library</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/library/src/main/java/com/wuman/androidimageloader/ImageLoader.java
+++ b/library/src/main/java/com/wuman/androidimageloader/ImageLoader.java
@@ -221,11 +221,11 @@ public final class ImageLoader {
      */
     private final LruCache<String, ImageError> mErrors;
 
-	/**
-	 * Allow only single concurrent request to given url. A list of callbacks for concurrent request attempts
-	 * is created and they are called when the initial ImageRequest is ready.
-	 */
-	private final Map<String, List<Callback>> concurrentRequests = new HashMap<String, List<Callback>>();
+    /**
+     * Allow only single concurrent request to given url. A list of callbacks for concurrent request attempts
+     * is created and they are called when the initial ImageRequest is ready.
+     */
+    private final Map<String, List<Callback>> concurrentRequests = new HashMap<String, List<Callback>>();
 
     /**
      * Creates an {@link ImageLoader}.
@@ -457,33 +457,33 @@ public final class ImageLoader {
                 }
                 return LoadResult.ERROR;
             } else {
-	            synchronized (concurrentRequests) {
-		            List<Callback> callbacks = concurrentRequests.get(url);
-		            if (callbacks == null) {
-			            callbacks = new ArrayList<Callback>();
-			            concurrentRequests.put(url, callbacks);
-		            }
+                synchronized (concurrentRequests) {
+                    List<Callback> callbacks = concurrentRequests.get(url);
+                    if (callbacks == null) {
+                        callbacks = new ArrayList<Callback>();
+                        concurrentRequests.put(url, callbacks);
+                    }
 
-		            // Add dummy callback;
-		            if (callback == null) {
-			            callback = new Callback() {
-				            @Override
-				            public void onImageLoaded(Bitmap bitmap, String url, LoadSource loadSource) {
-				            }
-
-				            @Override
-				            public void onImageError(String url, Throwable error) {
-				            }
-			            };
-		            }
-		            callbacks.add(callback);
-
-		            // Only initial request should be enqueued.
-		            if (callbacks.size() == 1) {
-			            ImageRequest request = new ImageRequest(url);
-			            enqueueRequest(request);
-		            }
-	            }
+                    // Add dummy callback;
+                    if (callback == null) {
+                        callback = new Callback() {
+                            @Override
+                            public void onImageLoaded(Bitmap bitmap, String url, LoadSource loadSource) {
+                            }
+                            
+                            @Override
+                            public void onImageError(String url, Throwable error) {
+                            }
+                        };
+                    }
+                    callbacks.add(callback);
+                    
+                    // Only initial request should be enqueued.
+                    if (callbacks.size() == 1) {
+                        ImageRequest request = new ImageRequest(url);
+                        enqueueRequest(request);
+                    }
+                }
 
                 return LoadResult.LOADING;
             }
@@ -889,20 +889,20 @@ public final class ImageLoader {
                 putError(mUrl, mError);
             }
 
-	        List<Callback> callbacks;
-	        synchronized (concurrentRequests) {
-		        callbacks = concurrentRequests.remove(mUrl);
-	        }
+            List<Callback> callbacks;
+            synchronized (concurrentRequests) {
+                callbacks = concurrentRequests.remove(mUrl);
+            }
 
-	        if (callbacks != null) {
-		        for (Callback callback : callbacks) {
-			        if (mBitmap != null) {
-				        callback.onImageLoaded(mBitmap, mUrl, mLoadSource);
-			        } else if (mError != null) {
-				        callback.onImageError(mUrl, mError.getCause());
-			        }
-		        }
-	        }
+            if (callbacks != null) {
+                for (Callback callback : callbacks) {
+                    if (mBitmap != null) {
+                        callback.onImageLoaded(mBitmap, mUrl, mLoadSource);
+                    } else if (mError != null) {
+                        callback.onImageError(mUrl, mError.getCause());
+                    }
+                }
+            }
         }
 
         public void writeBackResult() {

--- a/library/src/main/java/com/wuman/androidimageloader/ImageViewBinder.java
+++ b/library/src/main/java/com/wuman/androidimageloader/ImageViewBinder.java
@@ -1,14 +1,14 @@
 package com.wuman.androidimageloader;
 
+import android.animation.ObjectAnimator;
 import android.graphics.Bitmap;
+import android.os.Build;
+import android.view.ViewPropertyAnimator;
 import android.widget.AbsListView;
 import android.widget.AbsListView.OnScrollListener;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.ListAdapter;
-
-import com.nineoldandroids.animation.ObjectAnimator;
-import com.nineoldandroids.view.ViewPropertyAnimator;
 import com.wuman.androidimageloader.ImageLoader.LoadResult;
 import com.wuman.androidimageloader.ImageLoader.LoadSource;
 
@@ -35,7 +35,7 @@ public class ImageViewBinder extends AbstractViewBinder<ImageView> implements
     @Override
     public void unbind(ImageView view) {
         super.unbind(view);
-        ViewPropertyAnimator.animate(view).cancel();
+        // ViewPropertyAnimator.animate(view).cancel();
         view.setImageDrawable(null);
     }
 
@@ -67,7 +67,8 @@ public class ImageViewBinder extends AbstractViewBinder<ImageView> implements
     protected void onImageLoaded(ImageView view, Bitmap bitmap, String url,
             LoadSource loadSource) {
         view.setImageBitmap(bitmap);
-        if (loadSource != LoadSource.CACHE_MEMORY && mFadeIn) {
+
+        if (loadSource != LoadSource.CACHE_MEMORY && mFadeIn && Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
             ObjectAnimator.ofFloat(view, "alpha", 0.0f, 1.0f).setDuration(400)
                     .start();
         }


### PR DESCRIPTION
Hi. Thanks for a great library! I wrote a couple of fixes. Please merge if you find these commits useful.

1) Multiple concurrent requests to same URL were fired if the same image was shown multiple times on the screen.
2) NineOldAndroids has a memory leak. I don't remember the details anymore. It was a few months ago when I traced the problem. Anyway, let's use native animation if it is available. And anyway, maybe it's not even worth including a big library for such a minor fade in animation.
